### PR TITLE
The piece case changed according to the move side

### DIFF
--- a/xiangqi.js
+++ b/xiangqi.js
@@ -965,6 +965,7 @@ const Xiangqi = function(fen) {
     move.iccs = move_to_iccs(move, false);
     move.to = algebraic(move.to);
     move.from = algebraic(move.from);
+    move.piece = turn === RED ? move.piece.toUpperCase() : move.piece;
 
     let flags = '';
 


### PR DESCRIPTION
The `piece` is converted to upper case if the move is of `RED` side on the methods like `.move()`, `.moves()`, `.history()`, `.undo()` and `.redo()`, for better readability.

Following issue is resolved in this PR:
https://github.com/lengyanyu258/xiangqi.js/issues/10