### PR TITLE
fix: FEN validation for empty move/half-move fields

### DIFF
--- a/xiangqi.js
+++ b/xiangqi.js
@@ -185,12 +185,12 @@ const Xiangqi = function (fen) {
     }
 
     /* 2nd criterion: move number field is a integer value > 0? */
-    if (isNaN(tokens[5]) || parseInt(tokens[5], 10) <= 0) {
+    if (tokens[5] === '' || isNaN(tokens[5]) || parseInt(tokens[5], 10) <= 0) {
       return result(2);
     }
 
     /* 3rd criterion: half move counter is an integer >= 0? */
-    if (isNaN(tokens[4]) || parseInt(tokens[4], 10) < 0) {
+    if (tokens[4] === '' || isNaN(tokens[4]) || parseInt(tokens[4], 10) < 0) {
       return result(3);
     }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where `validate_fen` incorrectly accepts empty string tokens in the numeric fields (halfmove and move number).
Because `isNaN('') === false`, FEN strings with trailing spaces or missing values were previously treated as valid.

## Problem

Before this change, the following invalid FEN strings were accepted:

```javascript
const response = xiangqi.validate_fen(
  'rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 0 '
);
console.log(response);
// { valid: true, error_number: 0, error: 'No errors.' }
```

```javascript
const response = xiangqi.validate_fen(
  'rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 0    '
);
console.log(response);
// { valid: true, error_number: 0, error: 'No errors.' }
```

## Fix

This PR explicitly checks for empty string tokens in the numeric fields, ensuring that empty or whitespace-only values are rejected.

## After the Change

```javascript
const response = xiangqi.validate_fen(
  'rnbakabnr/9/1c5c1/p1p1p1p1p/9/9/P1P1P1P1P/1C5C1/9/RNBAKABNR r - - 0 '
);
console.log(response);
// {
//   valid: false,
//   error_number: 2,
//   error: '6th field (move number) must be a positive integer.'
// }
```